### PR TITLE
Feat/embed image

### DIFF
--- a/src/components/Configure/Configure.js
+++ b/src/components/Configure/Configure.js
@@ -107,6 +107,15 @@ function Configure(props) {
     props.changeSettings(true);
   }
 
+  function toggleSheetIsImageHandler(sheetIdx, colIdx) {
+    console.log('[Configure.js] toggleSheetIsImageHandler', sheetIdx);
+    const meta = props.meta;
+    const sheet = meta[sheetIdx];
+    sheet.columns[colIdx].isImage = !sheet.columns[colIdx].isImage;
+    props.updateMeta(meta);
+    props.changeSettings(true);
+  }
+
   function array_move(arr, old_index, new_index) {
     if (new_index >= arr.length) {
         var k = new_index - arr.length + 1;
@@ -204,7 +213,7 @@ function Configure(props) {
         tabs={tabs}
         ><div style={configBody}>
           { tab === 0 ? <SelectSheets sheets={props.meta} selectSheet={selectSheetHandler} changeOrder={changeSheetOrderHandler} changeName={changeSheetNameHandler} /> : null }
-          { tab === 1 ? <SelectColumns sheets={props.meta} colSelect={selectColumnHandler} changeName={changeColumnNameHandler} changeOrder={changeColumnOrderHandler}/> : null }
+          { tab === 1 ? <SelectColumns sheets={props.meta} colSelect={selectColumnHandler} changeName={changeColumnNameHandler} changeOrder={changeColumnOrderHandler} toggleIsImage={toggleSheetIsImageHandler} /> : null }
           { tab === 2 ? <ConfigureTab label={props.label} filename={props.filename} style={props.style} updateLabel={updateLabelHandler} updateButtonStyle={updateButtonStyleHandler} updateFilename={updateFilenameHandler}/> : null }
         </div>
       </Tabs>

--- a/src/components/Configure/SelectColumns/SelectColumns.js
+++ b/src/components/Configure/SelectColumns/SelectColumns.js
@@ -16,6 +16,7 @@ function SelectColumns(props) {
               colSelect={props.colSelect}
               changeName={props.changeName}
               changeOrder={props.changeOrder}
+              toggleIsImage={props.toggleIsImage}
               />
           </div>
         );

--- a/src/components/Configure/SelectColumns/Sheet/Column/Column.js
+++ b/src/components/Configure/SelectColumns/Sheet/Column/Column.js
@@ -17,7 +17,7 @@ const useStyles = makeStyles(theme => ({
     alignItems: 'center',
   },
   column: {
-    flexBasis: '50%',
+    flexBasis: '33%',
   },
   label: {
     display: 'block',
@@ -104,6 +104,16 @@ function Column(props) {
             <div className={classes.group}>
               <label className={classes.label}>Change Order</label>
               <Stepper min={1} max={props.cols.length} step={1} pageSteps={1} value={props.id + 1} onValueChange={value => props.changeOrder(value)} className={classes.stepper} />
+            </div>
+          </div>
+          <div className={classes.column}>
+            <div className={classes.group}>
+              <label className={classes.label}>Is Image</label>
+              <Checkbox
+                checked={props.isImage}
+                onChange={props.toggleIsImage}
+              >
+              </Checkbox>
             </div>
           </div>
         </AccordionDetails>

--- a/src/components/Configure/SelectColumns/Sheet/Sheet.js
+++ b/src/components/Configure/SelectColumns/Sheet/Sheet.js
@@ -11,8 +11,10 @@ function Sheets(props) {
           key={col.index}
           name={col.name}
           rename={col.changeName}
+          isImage={col.isImage}
           selected={col.selected}
           select={() => props.colSelect(props.id, index)}
+          toggleIsImage={() => props.toggleIsImage(props.id, index)}
           changeName={(name) => props.changeName(props.id, index, name)}
           cols={props.cols}
           changeOrder={(newPos) => props.changeOrder(props.id, index, newPos)}

--- a/src/components/func/func.js
+++ b/src/components/func/func.js
@@ -204,12 +204,13 @@ const revalidateMeta = (existing) => new Promise((resolve, reject) => {
   });
 });
 
-const exportToExcel = async (meta, env, filename) => new Promise(async (resolve, reject) => {
-  let xlsFile = "export.xlsx";
-  if (filename && filename.length > 0) {
-    xlsFile = filename + ".xlsx";
-  }
-    if (hasembecImage(meta)) {
+const exportToExcel = async (meta, env, filename) =>
+  new Promise(async (resolve, reject) => {
+    let xlsFile = "export.xlsx";
+    if (filename && filename.length > 0) {
+      xlsFile = filename + ".xlsx";
+    }
+    if (hasEmbedImage(meta)) {
       const workbook = new ExcelJS.Workbook();
       await buildExcelBlobWithEmbedImage(workbook, meta);
       const buffer = await workbook.xlsx.writeBuffer();
@@ -227,15 +228,17 @@ const exportToExcel = async (meta, env, filename) => new Promise(async (resolve,
         var wbout = XLSX.write(wb,wopts);
         saveAs(new Blob([wbout],{type:"application/octet-stream"}), xlsFile);
         resolve();
-    });
-  };
+      });
+    };
   });
 
-const hasembecImage = (meta) => {
+const hasEmbedImage = (meta) => {
   let hasImage = false;
+  console.log("[func.js] Checking for images in meta", meta);
   meta.forEach((sheet) => {
     if (sheet && sheet.columns) {
       sheet.columns.forEach((col) => {
+        console.log("[func.js] Checking column", col);
         if (col && col.isImage) {
           hasImage = true;
         }
@@ -248,11 +251,12 @@ const hasembecImage = (meta) => {
 
 // krisd: move excel creation to caller (to support extra export to methodss)
 // callback receives a blob to save or transfer
-const buildExcelBlob = async (wb, meta) => new Promise((resolve, reject) => {
+const buildExcelBlob = async (meta) => new Promise((resolve, reject) => {
   console.log("[func.js] Got Meta", meta);
   // func.saveSettings(meta, function(newSettings) {
     // console.log("Saved settings", newSettings);
   const worksheets = tableau.extensions.dashboardContent.dashboard.worksheets;
+  const wb = XLSX.utils.book_new();
   let totalSheets = 0;
   let sheetCount = 0;
   const sheetList = [];
@@ -388,13 +392,6 @@ const buildExcelBlob = async (wb, meta) => new Promise((resolve, reject) => {
 
       const headerRow = newSheet.getRow(1);
       headerRow.font = { bold: true };
-      headerRow.eachCell((cell) => {
-        cell.fill = {
-          type: 'pattern',
-          pattern: 'solid',
-          fgColor: { argb: 'FFEFD5' },
-        };
-      });
     }
   };
 

--- a/src/components/func/func.js
+++ b/src/components/func/func.js
@@ -76,6 +76,7 @@ const getSheetColumns = (sheet, existingCols, modified) => new Promise((resolve,
         col.dataType = columns[j].dataType;
         col.changeName = null;
         col.selected = false;
+        col.isImage = columns[j].isImage;
         cols.push(col);
       }
       for (var i = 0; i < existingCols.length; i++) {
@@ -93,6 +94,7 @@ const getSheetColumns = (sheet, existingCols, modified) => new Promise((resolve,
           ret.selected = existingCols[eIdx].selected;
           ret.changeName = existingCols[eIdx].changeName;
           ret.order = eIdx;
+          ret.isImage = existingCols[eIdx].isImage;
         } else {
           ret.order = maxPos;
           maxPos += 1;
@@ -106,6 +108,7 @@ const getSheetColumns = (sheet, existingCols, modified) => new Promise((resolve,
         newCol.name = columns[k].fieldName;
         newCol.dataType = columns[k].dataType;
         newCol.selected = true;
+        newCol.isImage = columns[k].isImage;
         newCol.order = k + 1;
         cols.push(newCol);
       }


### PR DESCRIPTION
## Overview
This pull request introduces an **“Is Image” toggle** for columns, enabling the extension to embed images directly into Excel files. If a column is marked as “Is Image,” its content will be fetched and inserted as an actual image in the exported workbook. When no columns are flagged as images, the export will fall back to the default text-based output.

### Key Changes
- **Configure.js**: Added `toggleSheetIsImageHandler` to handle image toggling in column settings.
- **SelectColumns/SelectColumns.js** and **SelectColumns/Sheet/Column.js**: Passed and handled the `toggleIsImage` prop to update the `isImage` state.
- **func.js**: 
  - Added `ExcelJS` for image embedding.
  - Created `hasEmbedImage` function to detect whether any column requires image export.
  - Implemented logic to fetch and embed images in the resulting Excel file.

### How to Test
1. Install or update the extension in Tableau.
2. Go to the “SelectColumns” tab.
3. Check the “Is Image” box for any column containing image URLs.
4. Export to Excel.
   - Confirm that the images appear directly in the Excel file, rather than as URLs.

### Additional Notes
- If images do not load, ensure that the host server allows CORS requests for the image URLs.
- `ExcelJS` may have some limitations or known issues with certain image formats or environments.
- For columns not marked as “Is Image,” the extension continues to use the existing `XLSX` approach.
